### PR TITLE
Fix release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
           ALLOW_TAG_PREFIX: "true"
-          RELEASE_NAME_PREFIX: HyP3 Testing
+          RELEASE_NAME_PREFIX: "HyP3 Testing "
 
       - name: Attempt fast-forward develop from main
         run: |


### PR DESCRIPTION
Release workflow currently produces a title like `HyP3 Testingv0.1.0` 

This should add the missing space. 