### PR TITLE
set tolerance for RTC rgb tifs

### DIFF
--- a/tests/test_tifs.py
+++ b/tests/test_tifs.py
@@ -44,6 +44,8 @@ def _get_tif_tolerances(file_name: str):
         rtol, atol = 2e-05, 1e-05
     if file_name.endswith('area.tif'):
         rtol, atol = 2e-05, 0.0
+    if file_name.endswith('rgb.tif'):
+        rtol, atol = 0.0, 1.0
 
     return rtol, atol
 


### PR DESCRIPTION
Golden tests pass with `atol=1.0`, fail with `atol=0.99`