### PR TITLE
Update SDK API URL constants

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.8
   - pip
   - gdal
-  - hyp3_sdk>=1.1,<2
+  - hyp3_sdk>=1.3,<2
   - jinja2
   - numpy
   - netCDF4  # provides xarray netCDF IO backend

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires='~=3.8',
 
     install_requires=[
-        'hyp3_sdk~=1.1',
+        'hyp3_sdk~=1.3',
         'jinja2',
         'numpy',
         'netCDF4',  # provides xarray netCDF IO backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def comparison_environments(tmp_path_factory, golden_dirs):
             path.mkdir(exist_ok=True, parents=True)
             comparison_dirs.append(path)
 
-    comparison_apis = [hyp3_sdk.HYP3_PROD, hyp3_sdk.HYP3_TEST]
+    comparison_apis = [hyp3_sdk.PROD_API, hyp3_sdk.TEST_API]
     return list(zip(comparison_dirs, comparison_apis))
 
 


### PR DESCRIPTION
Will be needed with the ~~pending~~ release of [`hyp3_sdk` v1.3.0](https://github.com/ASFHyP3/hyp3-sdk/pull/139)