### PR TITLE
drop unused s3pypi

### DIFF
--- a/conda-env.yml
+++ b/conda-env.yml
@@ -19,5 +19,3 @@ dependencies:
   - rasterio
   - wheel
   - xarray
-  - pip:
-      - s3pypi


### PR DESCRIPTION
Fixes dependency error causing hyp3-testing to be unusable -- turns out we don't actually use it