### PR TITLE
add l5 and l7 reproject golden tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `insar_gamma_golden.json.j2` Add tolerance and allowable excedeances for each file and use new pairs
 * `test_tifs.py` update to parse new tolerance information and perform unique workflow for InSAR jobs
 * `compare.py` create new `assert_within_tolerance` function to use file-specific tolerances
+* `autorift_golden.json.j2` includes L5+5, L7+7, L7+8, and L8+7 pairs in different projections to test reprojection code
 
 ### Added
 * `test_autorift.py` golden test for the autoRIFT plugin

--- a/hyp3_testing/templates/autorift_golden.json.j2
+++ b/hyp3_testing/templates/autorift_golden.json.j2
@@ -118,5 +118,25 @@
        ]
     },
     "job_type": "AUTORIFT"
+  },
+  {
+    "name": "{{ name }}",
+    "job_parameters": {
+      "granules": [
+        "LT05_L1TP_060018_19851028_20200918_02_T1",
+        "LT05_L1GS_061018_19860123_20200918_02_T2"
+       ]
+    },
+    "job_type": "AUTORIFT"
+  },
+  {
+    "name": "{{ name }}",
+    "job_parameters": {
+      "granules": [
+        "LE07_L1TP_061018_20120428_20200909_02_T1",
+        "LE07_L1TP_060018_20120726_20200908_02_T1"
+       ]
+    },
+    "job_type": "AUTORIFT"
   }
 ]

--- a/hyp3_testing/templates/autorift_golden.json.j2
+++ b/hyp3_testing/templates/autorift_golden.json.j2
@@ -138,5 +138,25 @@
        ]
     },
     "job_type": "AUTORIFT"
+  },
+  {
+    "name": "{{ name }}",
+    "job_parameters": {
+      "granules": [
+        "LC08_L1TP_060018_20130330_20200912_02_T1",
+        "LE07_L1TP_061018_20130415_20200907_02_T1"
+       ]
+    },
+    "job_type": "AUTORIFT"
+  },
+  {
+    "name": "{{ name }}",
+    "job_parameters": {
+      "granules": [
+        "LE07_L1TP_061018_20130314_20200908_02_T1",
+        "LC08_L1TP_060018_20130330_20200912_02_T1"
+       ]
+    },
+    "job_type": "AUTORIFT"
   }
 ]


### PR DESCRIPTION
Add in two more tests for L7 and L5 that require projection in golden tests. 
<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/hyp3-testing/compare/main...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->