### PR TITLE
allow searching by a different user than the authorized user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `test_tifs.py` update to parse new tolerance information and perform unique workflow for InSAR jobs
 * `compare.py` create new `assert_within_tolerance` function to use file-specific tolerances
 * `autorift_golden.json.j2` includes L5+5, L7+7, L7+8, and L8+7 pairs in different projections to test reprojection code
+* `--user` pytest CLI argument to allow finding products submitted by a different user than the authorized user
 
 ### Added
 * `test_autorift.py` golden test for the autoRIFT plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `test_tifs.py` update to parse new tolerance information and perform unique workflow for InSAR jobs
 * `compare.py` create new `assert_within_tolerance` function to use file-specific tolerances
 * `autorift_golden.json.j2` includes L5+5, L7+7, L7+8, and L8+7 pairs in different projections to test reprojection code
-* `--user` pytest CLI argument to allow finding products submitted by a different user than the authorized user
+* `--user-id` pytest CLI argument to allow finding products submitted by a different user than the authorized user
 
 ### Added
 * `test_autorift.py` golden test for the autoRIFT plugin

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ a couple options to pytest to help.
 
 * You can also specify an alternate `user_id`
   ```
-  pytest --user [USER_ID]
+  pytest --user-id [USER_ID]
   ```
   which will find jobs submitted by `USER_ID` instead of defaulting to jobs submitted by the authorized user. This is
   particularly useful when re-running a comparison run by someone else, or by the GitHub Actions user.

--- a/README.md
+++ b/README.md
@@ -129,3 +129,10 @@ a couple options to pytest to help.
   which will use the products found inside those directories (with `DIR1` being considered the golden set)
   or, if no products found, download the appropriate products to that directory (either from the 
   submission or the specified name)
+
+* You can also specify an alternate `user_id`
+  ```
+  pytest --user [USER_ID]
+  ```
+  which will find jobs submitted by `USER_ID` instead of defaulting to jobs submitted by the authorized user. This is
+  particularly useful when re-running a comparison run by someone else, or by the GitHub Actions user.

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python>=3.9
   - pip
   - gdal
-  - hyp3_sdk>=1.3
+  - hyp3_sdk>=2.1.1
   - jinja2
   - numpy
   - netCDF4  # provides xarray netCDF IO backend

--- a/hyp3_testing/helpers.py
+++ b/hyp3_testing/helpers.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 from glob import glob
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from zipfile import ZipFile
 
 from hyp3_sdk import Batch, HyP3, Job
@@ -20,9 +20,9 @@ def sort_jobs_by_parameters(jobs: Batch) -> Batch:
     return Batch(sorted_jobs)
 
 
-def get_jobs_in_environment(job_name, api):
+def get_jobs_in_environment(job_name: str, api: str, user_id: Optional[str]) -> Batch:
     hyp3 = HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
-    jobs = hyp3.find_jobs(name=job_name)
+    jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
     return sort_jobs_by_parameters(jobs)
 
 

--- a/hyp3_testing/helpers.py
+++ b/hyp3_testing/helpers.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 from glob import glob
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
 from zipfile import ZipFile
 
 from hyp3_sdk import Batch, HyP3, Job

--- a/hyp3_testing/helpers.py
+++ b/hyp3_testing/helpers.py
@@ -20,7 +20,7 @@ def sort_jobs_by_parameters(jobs: Batch) -> Batch:
     return Batch(sorted_jobs)
 
 
-def get_jobs_in_environment(job_name: str, api: str, user_id: Optional[str]) -> Batch:
+def get_jobs_in_environment(job_name: str, api: str, user_id: Optional[str] = None) -> Batch:
     hyp3 = HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
     jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
     return sort_jobs_by_parameters(jobs)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires='>=3.8',
 
     install_requires=[
-        'hyp3_sdk>=1.3',
+        'hyp3_sdk>=2.1.1',
         'jinja2',
         'numpy',
         'netCDF4',  # provides xarray netCDF IO backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def pytest_addoption(parser):
         "--golden-dirs", nargs=2, help="Main and develop directories to use for comparison"
     )
     parser.addoption(
-        "--user", nargs='?', help="Find jobs submitted by this user to compare"
+        "--user-id", nargs='?', help="Find jobs submitted by this user to compare"
     )
 
 
@@ -67,7 +67,7 @@ def golden_dirs(request):
 
 @pytest.fixture(scope='session')
 def user_id(request):
-    return request.config.getoption("--user")
+    return request.config.getoption("--user-id")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,13 @@ def pytest_addoption(parser):
         "--keep", action='store_true', help="Do not remove downloaded test products"
     )
     parser.addoption(
-        "--name", nargs='?', help="Find jobs by this name to compare"
+        "--name", nargs='?', help="Find jobs with this name to compare"
     )
     parser.addoption(
         "--golden-dirs", nargs=2, help="Main and develop directories to use for comparison"
+    )
+    parser.addoption(
+        "--user", nargs='?', help="Find jobs submitted by this user to compare"
     )
 
 
@@ -60,6 +63,11 @@ def job_name(request):
 @pytest.fixture(scope='session')
 def golden_dirs(request):
     return request.config.getoption("--golden-dirs")
+
+
+@pytest.fixture(scope='session')
+def user_id(request):
+    return request.config.getoption("--user")
 
 
 @pytest.fixture
@@ -106,15 +114,15 @@ def rtc_tolerances(job_name):
 
 
 @pytest.fixture(scope='module')
-def jobs_info(comparison_environments, job_name):
+def jobs_info(comparison_environments, job_name, user_id):
     (main_dir, main_api), (develop_dir, develop_api) = comparison_environments
     if job_name is None:
         submission_report = main_dir / f'{main_dir.name}_submission.json'
         submission_details = json.loads(submission_report.read_text())
         job_name = submission_details['name']
 
-    main_jobs = helpers.get_jobs_in_environment(job_name, main_api)
-    develop_jobs = helpers.get_jobs_in_environment(job_name, develop_api)
+    main_jobs = helpers.get_jobs_in_environment(job_name, main_api, user_id=user_id)
+    develop_jobs = helpers.get_jobs_in_environment(job_name, develop_api, user_id=user_id)
 
     jobs_dict = {}
     for main_job, develop_job in zip(main_jobs, develop_jobs):

--- a/tests/test_autorift.py
+++ b/tests/test_autorift.py
@@ -48,7 +48,7 @@ def test_golden_wait(comparison_environments, job_name):
             job_name = submission_details['name']
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
-        jobs = hyp3.find_jobs(name=job_name)
+        jobs = hyp3.find_jobs(name=job_name, user_id=os.environ.get('HYP3_TESTING_USER'))
         _ = hyp3.watch(jobs)
 
 

--- a/tests/test_autorift.py
+++ b/tests/test_autorift.py
@@ -73,6 +73,9 @@ def test_golden_products(comparison_environments, job_name, keep):
                         f'    Develop: {develop_jobs}')
 
     for main_job, develop_job in zip(main_jobs, develop_jobs):
+        if main_job.failed() or develop_job.failed():
+            continue
+
         main_nc = main_job.download_files(main_dir)[0]
         main_hash = main_nc.stem
 

--- a/tests/test_autorift.py
+++ b/tests/test_autorift.py
@@ -36,7 +36,7 @@ def test_golden_submission(comparison_environments):
 
 @pytest.mark.timeout(10800)  # 3 hours
 @pytest.mark.dependency()
-def test_golden_wait(comparison_environments, job_name):
+def test_golden_wait(comparison_environments, job_name, user_id):
     for dir_, api in comparison_environments:
         products = helpers.find_products(dir_, pattern='*.nc')
         if products:
@@ -48,7 +48,7 @@ def test_golden_wait(comparison_environments, job_name):
             job_name = submission_details['name']
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
-        jobs = hyp3.find_jobs(name=job_name, user_id=os.environ.get('HYP3_TESTING_USER'))
+        jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
         _ = hyp3.watch(jobs)
 
 

--- a/tests/test_insar.py
+++ b/tests/test_insar.py
@@ -37,7 +37,7 @@ def test_golden_submission(comparison_environments):
 
 @pytest.mark.timeout(10800)  # 180 minutes as InSAR jobs can take ~2.5 hrs
 @pytest.mark.dependency()
-def test_golden_wait(comparison_environments, job_name):
+def test_golden_wait(comparison_environments, job_name, user_id):
     for dir_, api in comparison_environments:
         if job_name is None:
             submission_report = dir_ / f'{dir_.name}_submission.json'
@@ -45,7 +45,7 @@ def test_golden_wait(comparison_environments, job_name):
             job_name = submission_details['name']
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
-        jobs = hyp3.find_jobs(name=job_name)
+        jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
         _ = hyp3.watch(jobs)
 
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -37,7 +37,7 @@ def test_golden_submission(comparison_environments):
 
 @pytest.mark.timeout(5400)  # 90 minutes as RTC jobs can take ~1.5 hr
 @pytest.mark.dependency()
-def test_golden_wait(comparison_environments, job_name):
+def test_golden_wait(comparison_environments, job_name, user_id):
     for dir_, api in comparison_environments:
         if job_name is None:
             submission_report = dir_ / f'{dir_.name}_submission.json'
@@ -45,7 +45,7 @@ def test_golden_wait(comparison_environments, job_name):
             job_name = submission_details['name']
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
-        jobs = hyp3.find_jobs(name=job_name)
+        jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
         _ = hyp3.watch(jobs)
 
 


### PR DESCRIPTION
This is useful, in particular, when running a golden test from GitHub, but later wanting to pull it down locally without having to log in as the hyp3 testing user.

Alternative: Instead of an env variable, this could be a pytest CLI switch. :thinking: 