### PR TITLE
Better handling of some edge cases

### DIFF
--- a/tests/test_autorift.py
+++ b/tests/test_autorift.py
@@ -56,7 +56,7 @@ def test_golden_wait(comparison_environments, job_name, user_id):
 
 
 @pytest.mark.dependency(depends=['test_golden_wait'])
-def test_golden_products(comparison_environments, job_name, keep):
+def test_golden_products(comparison_environments, job_name, user_id, keep):
     (main_dir, main_api), (develop_dir, develop_api) = comparison_environments
     if job_name is None:
         submission_report = main_dir / f'{main_dir.name}_submission.json'
@@ -66,8 +66,8 @@ def test_golden_products(comparison_environments, job_name, keep):
     failure_count = 0
     messages = []
 
-    main_jobs = helpers.get_jobs_in_environment(job_name, main_api)
-    develop_jobs = helpers.get_jobs_in_environment(job_name, develop_api)
+    main_jobs = helpers.get_jobs_in_environment(job_name, main_api, user_id)
+    develop_jobs = helpers.get_jobs_in_environment(job_name, develop_api, user_id)
 
     main_succeeded = main_jobs._count_statuses()['SUCCEEDED']
     develop_succeeded = develop_jobs._count_statuses()['SUCCEEDED']

--- a/tests/test_insar.py
+++ b/tests/test_insar.py
@@ -57,6 +57,8 @@ def test_golden_wait(comparison_environments, job_name, user_id):
 def test_golden_job_succeeds(jobs_info):
     main_succeeds = sum([value['main']['succeeded'] for value in jobs_info.values()])
     develop_succeeds = sum([value['develop']['succeeded'] for value in jobs_info.values()])
+    assert main_succeeds != 0
+    assert develop_succeeds != 0
     assert main_succeeds == develop_succeeds
 
 

--- a/tests/test_insar.py
+++ b/tests/test_insar.py
@@ -47,6 +47,9 @@ def test_golden_wait(comparison_environments, job_name, user_id):
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
         jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
+
+        assert len(jobs) > 0  # will throw if job_name not associated with user_id
+
         _ = hyp3.watch(jobs)
 
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -56,6 +56,8 @@ def test_golden_wait(comparison_environments, job_name, user_id):
 def test_golden_job_succeeds(jobs_info):
     main_succeeds = sum([value['main']['succeeded'] for value in jobs_info.values()])
     develop_succeeds = sum([value['develop']['succeeded'] for value in jobs_info.values()])
+    assert main_succeeds != 0
+    assert develop_succeeds != 0
     assert main_succeeds == develop_succeeds
 
 

--- a/tests/test_rtc.py
+++ b/tests/test_rtc.py
@@ -46,6 +46,9 @@ def test_golden_wait(comparison_environments, job_name, user_id):
 
         hyp3 = hyp3_sdk.HyP3(api, os.environ.get('EARTHDATA_LOGIN_USER'), os.environ.get('EARTHDATA_LOGIN_PASSWORD'))
         jobs = hyp3.find_jobs(name=job_name, user_id=user_id)
+
+        assert len(jobs) > 0  # will throw if job_name not associated with user_id
+
         _ = hyp3.watch(jobs)
 
 


### PR DESCRIPTION
* Now that we allow `user_id` to be set,  it's possible to provide a `project_name` that is not associated with the provided `user_id`, and thus, no jobs will be found; assert at least 1 job is found in each deployment
* If all jobs fail in both deployments, fail. 
* actually pass user_id through in `autorift.test_golden_products`