### PR TITLE
Separate Imaginary and Real Components for Complex Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `test_autorift.py` golden test for the autoRIFT plugin
 
 ### Changed
+* Burst InSAR now tests complex datasets by separating the real and imaginary components and then testing them separately.
 * InSAR Gamma tests so that they do not use per-image threshold and instead analyze metadata, coregistration, nodata coverage, and dataproduct quality
 * RTC and autoRIFT golden tests now sleep for 60 seconds between requests for job status
 * `conda-env.yml` has been renamed to `environment.yml` to follow standard naming conventions 

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -70,7 +70,7 @@ def test_golden_tif_names(jobs_info):
         assert main_normalized_files == develop_normalized_files
 
 
-def comparisons(main_ds, develop_ds, pixel_size):
+def _comparisons(main_ds, develop_ds, pixel_size):
     compare.images_are_within_offset_threshold(main_ds, develop_ds, pixel_size=pixel_size,
                                                 offset_threshold=5.0)
     compare.maskes_are_within_similarity_threshold(main_ds, develop_ds, mask_rate=0.98)
@@ -109,10 +109,10 @@ def test_golden_burst_insar(comparison_environments, jobs_info, keep):
                     pixel_size = gdal.Info(str(main_tif), format='json')['geoTransform'][1]
                     # OpenCV does not support complex data, so we must compare each component as real values.
                     if main_ds.dtype in ('complex32', 'complex64'):
-                        comparisons(main_ds.real, develop_ds.real, pixel_size)
-                        comparisons(main_ds.imag, develop_ds.imag, pixel_size)
+                        _comparisons(main_ds.real, develop_ds.real, pixel_size)
+                        _comparisons(main_ds.imag, develop_ds.imag, pixel_size)
                     else:
-                        comparisons(main_ds, develop_ds, pixel_size)
+                        _comparisons(main_ds, develop_ds, pixel_size)
 
                     if '_unw_phase.tif' in str(main_tif):
                         compare.nodata_count_change_are_within_threshold(main_ds, develop_ds, threshold=0.01)

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -107,7 +107,7 @@ def test_golden_burst_insar(comparison_environments, jobs_info, keep):
 
                     pixel_size = gdal.Info(str(main_tif), format='json')['geoTransform'][1]
                     # OpenCV does not support complex data, so we must compare each component as real values.
-                    if main_ds.dtype == 'complex64' or main_ds.dtype == 'complex32':
+                    if main_ds.dtype in ('complex32', 'complex64'):
                         comparisons(main_ds.real, develop_ds.real, pixel_size)
                         comparisons(main_ds.imag, develop_ds.imag, pixel_size)
                     else:

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -70,6 +70,13 @@ def test_golden_tif_names(jobs_info):
         assert main_normalized_files == develop_normalized_files
 
 
+def comparisons(main_ds, develop_ds, pixel_size):
+    compare.images_are_within_offset_threshold(main_ds, develop_ds, pixel_size=pixel_size,
+                                                offset_threshold=5.0)
+    compare.maskes_are_within_similarity_threshold(main_ds, develop_ds, mask_rate=0.98)
+    compare.values_are_within_statistic(main_ds, develop_ds, confidence_level=0.99)
+
+
 @pytest.mark.dependency(depends=['test_golden_wait'])
 def test_golden_burst_insar(comparison_environments, jobs_info, keep):
     (main_dir, main_api), (develop_dir, develop_api) = comparison_environments
@@ -98,12 +105,6 @@ def test_golden_burst_insar(comparison_environments, jobs_info, keep):
 
                 try:
                     compare.compare_raster_info(main_tif, develop_tif)
-
-                    def comparisons(main_ds, develop_ds, pixel_size):
-                        compare.images_are_within_offset_threshold(main_ds, develop_ds, pixel_size=pixel_size,
-                                                                   offset_threshold=5.0)
-                        compare.maskes_are_within_similarity_threshold(main_ds, develop_ds, mask_rate=0.98)
-                        compare.values_are_within_statistic(main_ds, develop_ds, confidence_level=0.99)
 
                     pixel_size = gdal.Info(str(main_tif), format='json')['geoTransform'][1]
                     # OpenCV does not support complex data, so we must compare each component as real values.

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -107,7 +107,7 @@ def test_golden_burst_insar(comparison_environments, jobs_info, keep):
 
                     pixel_size = gdal.Info(str(main_tif), format='json')['geoTransform'][1]
                     # OpenCV does not support complex data, so we must compare each component as real values.
-                    if main_ds.dtype == 'complex64':
+                    if main_ds.dtype == 'complex64' or main_ds.dtype == 'complex32':
                         comparisons(main_ds.real, develop_ds.real, pixel_size)
                         comparisons(main_ds.imag, develop_ds.imag, pixel_size)
                     else:

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -101,7 +101,7 @@ def test_golden_burst_insar(comparison_environments, jobs_info, keep):
 
                     def comparisons(main_ds, develop_ds, pixel_size):
                         compare.images_are_within_offset_threshold(main_ds, develop_ds, pixel_size=pixel_size,
-                                                                    offset_threshold=5.0)
+                                                                   offset_threshold=5.0)
                         compare.maskes_are_within_similarity_threshold(main_ds, develop_ds, mask_rate=0.98)
                         compare.values_are_within_statistic(main_ds, develop_ds, confidence_level=0.99)
 

--- a/tests/test_burst_insar.py
+++ b/tests/test_burst_insar.py
@@ -72,7 +72,7 @@ def test_golden_tif_names(jobs_info):
 
 def _comparisons(main_ds, develop_ds, pixel_size):
     compare.images_are_within_offset_threshold(main_ds, develop_ds, pixel_size=pixel_size,
-                                                offset_threshold=5.0)
+                                               offset_threshold=5.0)
     compare.maskes_are_within_similarity_threshold(main_ds, develop_ds, mask_rate=0.98)
     compare.values_are_within_statistic(main_ds, develop_ds, confidence_level=0.99)
 


### PR DESCRIPTION
OpenCV does not support complex data types, but we still want to test them. This PR checks for complex datasets and does the comparisons on the imaginary and real components, separately - i.e. complex_ds.real and complex_ds.imag which are both np.float32.