### PR TITLE
update rtc golden tests for s1c

### DIFF
--- a/hyp3_testing/templates/rtc_gamma_golden.json.j2
+++ b/hyp3_testing/templates/rtc_gamma_golden.json.j2
@@ -117,7 +117,7 @@
     "name": "{{ name }}",
     "job_parameters": {
       "granules": [
-        "S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8"
+        "S1C_IW_SLC__1SDV_20250424T040225_20250424T040252_002030_004263_5DBF"
       ],
       "resolution": 20.0,
       "scale": "power",
@@ -174,7 +174,7 @@
     "name": "{{ name }}",
     "job_parameters": {
       "granules": [
-        "S1A_IW_GRDH_1SDV_20170823T011304_20170823T011316_018044_01E4B6_3F53"
+        "S1C_IW_GRDH_1SDV_20250416T182944_20250416T183014_001922_003C0B_09D3"
       ],
       "resolution": 30.0,
       "radiometry": "sigma0",


### PR DESCRIPTION
10 test cases total. Old scenes vs new scenes keeps a health mix of A vs B vs C, SLC vs GRDH, single-pol vs dual pol, vertical vs horizontal. 

| old | new |
| --- | --- |
| S1A SLC SV |  |
| S1A SLC SH |  |
| S1A SLC DV |  |
| S1B SLC DH |  |
| S1A GRDH DV | | 
| S1A SLC SV |  |
| S1A SLC SV | S1C SLC DV |
| S1B GRDH DH |  |
| S1B DRDH DH |  |
| S1A GRDH DV | S1C GRDH DV |