### PR TITLE
switch to arm runner

### DIFF
--- a/.github/workflows/golden_autorift.yml
+++ b/.github/workflows/golden_autorift.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_autorift.yml
+++ b/.github/workflows/golden_autorift.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_burst_insar.yml
+++ b/.github/workflows/golden_burst_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_burst_insar.yml
+++ b/.github/workflows/golden_burst_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_insar.yml
+++ b/.github/workflows/golden_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_insar.yml
+++ b/.github/workflows/golden_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_multiburst_insar.yml
+++ b/.github/workflows/golden_multiburst_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_multiburst_insar.yml
+++ b/.github/workflows/golden_multiburst_insar.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_rtc.yml
+++ b/.github/workflows/golden_rtc.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/golden_rtc.yml
+++ b/.github/workflows/golden_rtc.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   golden:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,12 +9,16 @@ jobs:
 
   call-ruff-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@arm-runner
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@arm-runner # TODO: pin to latest release
     permissions:
       contents: read
+    with:
+      runner: ubuntu-24.04-arm
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@arm-runner
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@arm-runner # TODO: pin to latest release
     permissions:
       contents: read
+    with:
+      runner: ubuntu-24.04-arm

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.18.1
 
   call-ruff-workflow:
+    runs-on: ubuntu-24.04-arm
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.18.1
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -17,4 +17,8 @@ jobs:
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.18.1
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@arm-runner
+    permissions:
+      contents: read
+    with:
+      runner: ubuntu-24.04-arm

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read
     with:
-      runner: ubuntu-24.04-arm
+      runner: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
@@ -21,4 +21,4 @@ jobs:
     permissions:
       contents: read
     with:
-      runner: ubuntu-24.04-arm
+      runner: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,7 +9,7 @@ jobs:
 
   call-ruff-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@arm-runner # TODO: pin to latest release
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.19.0
     permissions:
       contents: read
     with:
@@ -17,7 +17,7 @@ jobs:
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@arm-runner # TODO: pin to latest release
+    uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@v0.19.0
     permissions:
       contents: read
     with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -8,10 +8,12 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.18.1
 
   call-ruff-workflow:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      # Docs: https://github.com/ASFHyP3/actions
-      - uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.18.1
+    # Docs: https://github.com/ASFHyP3/actions
+    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@arm-runner
+    permissions:
+      contents: read
+    with:
+      runner: ubuntu-24.04-arm
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,13 +12,9 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@arm-runner
     permissions:
       contents: read
-    with:
-      runner: ubuntu-24.04-arm
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions
     uses: ASFHyP3/actions/.github/workflows/reusable-mypy.yml@arm-runner
     permissions:
       contents: read
-    with:
-      runner: ubuntu-24.04-arm

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,8 +9,9 @@ jobs:
 
   call-ruff-workflow:
     runs-on: ubuntu-24.04-arm
-    # Docs: https://github.com/ASFHyP3/actions
-    uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.18.1
+    steps:
+      # Docs: https://github.com/ASFHyP3/actions
+      - uses: ASFHyP3/actions/.github/workflows/reusable-ruff.yml@v0.18.1
 
   call-mypy-workflow:
     # Docs: https://github.com/ASFHyP3/actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
+    runs-on: ubuntu-24.04-arm # TODO: revert to ubuntu-latest after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04-arm # TODO: remove after fixing https://github.com/ASFHyP3/hyp3-testing/issues/128
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   pytest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
GH Actions workaround for https://github.com/ASFHyP3/hyp3-testing/issues/128

TODO:

- [x] Determine how to specify the runner for the `ruff` and `mypy` workflows
- [x] Run all mamba-dependent workflows on arm
- [x] Update `ruff` and `mypy` action pins after releasing https://github.com/ASFHyP3/actions/pull/290
- [x] Confirm at least one golden test still works: https://github.com/ASFHyP3/hyp3-testing/actions/runs/14984279139