### PR TITLE
add S1D RTC golden case

### DIFF
--- a/hyp3_testing/templates/rtc_gamma_golden.json.j2
+++ b/hyp3_testing/templates/rtc_gamma_golden.json.j2
@@ -136,6 +136,25 @@
     "name": "{{ name }}",
     "job_parameters": {
       "granules": [
+        "S1D_IW_SLC__1SDV_20260603T092214_20260603T092229_003070_0054E0_1B2E"
+      ],
+      "resolution": 20.0,
+      "scale": "power",
+      "speckle_filter": false,
+      "include_dem": false,
+      "include_inc_map": false,
+      "include_rgb": false,
+      "include_scattering_area": false,
+      "radiometry": "gamma0",
+      "dem_matching": false,
+      "dem_name": "copernicus"
+    },
+    "job_type": "RTC_GAMMA"
+  },
+  {
+    "name": "{{ name }}",
+    "job_parameters": {
+      "granules": [
         "S1B_IW_GRDH_1SDH_20180603T071934_20180603T071946_011205_014909_AF96"
       ],
       "resolution": 30.0,


### PR DESCRIPTION
Add an S1D RTC_GAMMA golden test case.

Validated with `pytest tests/test_rtc.py`. The new S1D case completed successfully; the remaining failure is from an existing S1C RTC comparison case.